### PR TITLE
Add auto redirect on login

### DIFF
--- a/myapp/frontend/src/pages/Login.jsx
+++ b/myapp/frontend/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../api';
 
@@ -6,6 +6,13 @@ export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- redirect authenticated users away from the login page using `useEffect`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68659ae7a1948321921552863ecc3a5a