### PR TITLE
Ensure stable React keys for subjects

### DIFF
--- a/myapp/backend/routes/subjects.py
+++ b/myapp/backend/routes/subjects.py
@@ -26,7 +26,11 @@ def list_subjects():
     else:
         query = {}
     subjects = mongo.db.subjects.find(query)
-    data = [Subject.from_dict(s).to_dict() for s in subjects]
+    data = []
+    for s in subjects:
+        item = Subject.from_dict(s).to_dict()
+        item['id'] = str(s['_id'])
+        data.append(item)
     return jsonify(data)
 
 

--- a/myapp/frontend/src/pages/Dashboard.jsx
+++ b/myapp/frontend/src/pages/Dashboard.jsx
@@ -35,7 +35,7 @@ export default function Dashboard() {
         ) : (
           subjects.map((s) => (
             <div
-              key={s.code}
+              key={s.id}
               style={{ border: '1px solid #ccc', padding: '8px', margin: '8px' }}
             >
               <h3>


### PR DESCRIPTION
## Summary
- include stable `id` property for each subject from backend
- use that `id` as React `key` in Dashboard

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659969a5608321920bb14574213477