### PR TITLE
Implement submission workflow

### DIFF
--- a/myapp/backend/app.py
+++ b/myapp/backend/app.py
@@ -1,9 +1,10 @@
-from flask import Flask
+from flask import Flask, send_from_directory
 from flask_cors import CORS
 from flask_pymongo import PyMongo
 from flask_jwt_extended import JWTManager
 from .config import Config
 from .routes import bp as api_bp
+import os
 
 mongo = PyMongo()
 jwt = JWTManager()
@@ -16,6 +17,15 @@ def create_app():
     mongo.init_app(app)
     jwt.init_app(app)
     app.config['MONGO'] = mongo
+
+    upload_folder = os.path.join(os.path.dirname(__file__), 'uploads')
+    os.makedirs(upload_folder, exist_ok=True)
+    app.config['UPLOAD_FOLDER'] = upload_folder
+
+    @app.route('/uploads/<path:path>')
+    def uploaded_file(path):
+        return send_from_directory(upload_folder, path)
+
     app.register_blueprint(api_bp, url_prefix='/api')
     return app
 

--- a/myapp/backend/load_initial_data.py
+++ b/myapp/backend/load_initial_data.py
@@ -21,14 +21,16 @@ db.users.insert_many([
         'name': 'Ana',
         'role': 'professor',
         'password_hash': prof_hash,
-        'subject_codes': ['CS101', 'MA101']
+        'subject_codes': ['CS101', 'MA101'],
+        'nip': 'P00000001'
     },
     {
         'email': 'maria@uc3m.es',
         'name': 'Maria',
         'role': 'student',
         'password_hash': student_hash,
-        'subject_codes': ['CS101']
+        'subject_codes': ['CS101'],
+        'nia': '100000001'
     }
 ])
 

--- a/myapp/backend/routes/resources.py
+++ b/myapp/backend/routes/resources.py
@@ -3,6 +3,8 @@ from flask_jwt_extended import jwt_required, get_jwt, get_jwt_identity
 from bson import ObjectId
 from . import bp
 from flask import current_app
+from werkzeug.utils import secure_filename
+import os
 from datetime import datetime
 
 
@@ -48,21 +50,77 @@ def delete_resource(rid):
     return jsonify({'success': True})
 
 
-@bp.route('/resources/<rid>/submissions', methods=['POST'])
+@bp.route('/resources/<rid>/submit', methods=['POST'])
 @jwt_required()
-def create_submission(rid):
+def submit_file(rid):
+    """Allow students to upload an exercise file"""
     err = _student_required()
     if err:
         return err
     mongo = get_db()
-    data = request.get_json() or {}
-    sub = {
+    resource = mongo.db.resources.find_one({'_id': ObjectId(rid)})
+    if not resource:
+        return jsonify({'error': 'Resource not found'}), 404
+    due = resource.get('due_date')
+    if due and datetime.utcnow() > due:
+        return jsonify({'error': 'Past due date'}), 400
+    file = request.files.get('file')
+    if not file:
+        return jsonify({'error': 'No file provided'}), 400
+
+    email = get_jwt_identity()
+    base = os.path.join(current_app.config['UPLOAD_FOLDER'], rid, email)
+    os.makedirs(base, exist_ok=True)
+    filename = secure_filename(file.filename)
+    relative = os.path.join(rid, email, filename)
+    filepath = os.path.join(current_app.config['UPLOAD_FOLDER'], relative)
+    file.save(filepath)
+
+    data = {
         'resource_id': ObjectId(rid),
-        'student_email': get_jwt_identity(),
-        'files': data.get('files', []),
-        'grade': None,
-        'feedback': None,
+        'student_email': email,
+        'file_path': relative,
         'submitted_at': datetime.utcnow(),
     }
-    result = mongo.db.submissions.insert_one(sub)
-    return jsonify({'id': str(result.inserted_id)})
+    existing = mongo.db.submissions.find_one({'resource_id': ObjectId(rid), 'student_email': email})
+    if existing:
+        mongo.db.submissions.update_one({'_id': existing['_id']}, {'$set': data})
+    else:
+        data['grade'] = None
+        mongo.db.submissions.insert_one(data)
+    return jsonify({'message': 'Submitted successfully'})
+
+
+@bp.route('/resources/<rid>/submissions', methods=['GET'])
+@jwt_required()
+def list_submissions(rid):
+    err = _professor_required()
+    if err:
+        return err
+    mongo = get_db()
+    subs = mongo.db.submissions.find({'resource_id': ObjectId(rid)})
+    result = []
+    for s in subs:
+        user = mongo.db.users.find_one({'email': s['student_email']})
+        name = user.get('name') if user else s['student_email']
+        result.append({
+            'id': str(s['_id']),
+            'student_email': s['student_email'],
+            'name': name,
+            'file_url': '/uploads/' + s['file_path'],
+            'grade': s.get('grade'),
+        })
+    return jsonify(result)
+
+
+@bp.route('/submissions/<sid>', methods=['PATCH'])
+@jwt_required()
+def grade_submission(sid):
+    err = _professor_required()
+    if err:
+        return err
+    mongo = get_db()
+    data = request.get_json() or {}
+    grade = data.get('grade')
+    mongo.db.submissions.update_one({'_id': ObjectId(sid)}, {'$set': {'grade': grade}})
+    return jsonify({'success': True})

--- a/myapp/frontend/src/index.js
+++ b/myapp/frontend/src/index.js
@@ -14,6 +14,7 @@ import Dashboard from './pages/Dashboard';
 import SubjectDetail from './pages/SubjectDetail';
 import NewResource from './pages/NewResource';
 import PrivateRoute from './PrivateRoute';
+import ReviewSubmissions from './pages/ReviewSubmissions';
 
 function App() {
   return (
@@ -44,6 +45,15 @@ function App() {
           element={
             <PrivateRoute>
               <NewResource />
+            </PrivateRoute>
+          }
+        />
+
+        <Route
+          path="/resources/:id/review"
+          element={
+            <PrivateRoute>
+              <ReviewSubmissions />
             </PrivateRoute>
           }
         />

--- a/myapp/frontend/src/pages/ReviewSubmissions.js
+++ b/myapp/frontend/src/pages/ReviewSubmissions.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../api';
+
+export default function ReviewSubmissions() {
+  const { id } = useParams();
+  const [subs, setSubs] = useState([]);
+
+  useEffect(() => {
+    api.get(`/resources/${id}/submissions`).then((res) => setSubs(res.data));
+  }, [id]);
+
+  const updateGrade = async (sid, grade) => {
+    await api.patch(`/submissions/${sid}`, { grade });
+  };
+
+  return (
+    <div>
+      <h2>Submissions</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>File</th>
+            <th>Grade</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {subs.map((s, i) => (
+            <tr key={s.id}>
+              <td>{s.name}</td>
+              <td>
+                <a href={s.file_url} target="_blank" rel="noopener noreferrer">
+                  Download
+                </a>
+              </td>
+              <td>
+                <input
+                  type="number"
+                  value={s.grade ?? ''}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setSubs((prev) => {
+                      const copy = [...prev];
+                      copy[i] = { ...copy[i], grade: val };
+                      return copy;
+                    });
+                  }}
+                />
+              </td>
+              <td>
+                <button onClick={() => updateGrade(s.id, s.grade)}>✅</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/myapp/frontend/src/pages/SubjectDetail.jsx
+++ b/myapp/frontend/src/pages/SubjectDetail.jsx
@@ -1,8 +1,30 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import api from '../api';
 import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
+
+function UploadButton({ resourceId }) {
+  const inputRef = useRef();
+  const handleUpload = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    api
+      .post(`/resources/${resourceId}/submit`, fd)
+      .then(() => alert('Submitted successfully'))
+      .catch(() => alert('Error submitting'));
+  };
+  return (
+    <>
+      <button onClick={() => inputRef.current && inputRef.current.click()} style={{ marginLeft: '8px' }}>
+        Submit
+      </button>
+      <input type="file" ref={inputRef} onChange={handleUpload} style={{ display: 'none' }} />
+    </>
+  );
+}
 
 export default function SubjectDetail() {
   const { code } = useParams();
@@ -48,16 +70,30 @@ export default function SubjectDetail() {
       </div>
       <h3>Resources</h3>
       <ul>
-        {resources.map((r) => (
-          <li key={r.id} style={{ marginBottom: '8px' }}>
-            {r.title} ({r.type})
-            {role === 'student' && r.type === 'practice' && (
-              <button onClick={() => alert('TODO')} style={{ marginLeft: '8px' }}>
-                Submit
-              </button>
-            )}
-          </li>
-        ))}
+        {resources.map((r) => {
+          const showDue = r.due_date ? ` (Due: ${new Date(r.due_date).toLocaleDateString()})` : '';
+          return (
+            <li key={r.id} style={{ marginBottom: '8px' }}>
+              {r.title} ({r.type}){showDue}
+              {role === 'student' && r.type === 'exercise' && (
+                <UploadButton resourceId={r.id} />
+              )}
+              {role === 'student' && r.type === 'practice' && (
+                <button onClick={() => alert('TODO')} style={{ marginLeft: '8px' }}>
+                  Start
+                </button>
+              )}
+              {role === 'professor' && r.type === 'exercise' && (
+                <button
+                  onClick={() => navigate(`/resources/${r.id}/review`)}
+                  style={{ marginLeft: '8px' }}
+                >
+                  Revisar
+                </button>
+              )}
+            </li>
+          );
+        })}
       </ul>
       {role === 'professor' && (
         <Link


### PR DESCRIPTION
## Summary
- add server route to serve uploaded files
- extend resources routes to handle exercise submissions
- seed demo users with NIA/NIP
- allow students to submit exercises from subject detail page
- enable professors to review and grade submissions

## Testing
- `python -m py_compile myapp/backend/app.py myapp/backend/routes/resources.py myapp/backend/load_initial_data.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865ab83f2348321ae35bd07c74688e3