### PR TITLE
Improve resources review and details

### DIFF
--- a/myapp/frontend/src/pages/ReviewSubmissions.js
+++ b/myapp/frontend/src/pages/ReviewSubmissions.js
@@ -1,21 +1,34 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import api from '../api';
 
 export default function ReviewSubmissions() {
-  const { id } = useParams();
+  const { id, code } = useParams();
+  const navigate = useNavigate();
   const [subs, setSubs] = useState([]);
 
   useEffect(() => {
-    api.get(`/resources/${id}/submissions`).then((res) => setSubs(res.data));
+    api
+      .get(`/resources/${id}/submissions`)
+      .then((res) =>
+        setSubs(res.data.map((s) => ({ ...s, originalGrade: s.grade })))
+      );
   }, [id]);
 
-  const updateGrade = async (sid, grade) => {
+  const updateGrade = async (sid, grade, index) => {
     await api.patch(`/submissions/${sid}`, { grade });
+    setSubs((prev) => {
+      const copy = [...prev];
+      copy[index] = { ...copy[index], originalGrade: grade };
+      return copy;
+    });
   };
 
   return (
     <div>
+      <button onClick={() => navigate(`/subjects/${code}`)} style={{ marginBottom: '16px' }}>
+        ← Volver a Asignatura
+      </button>
       <h2>Submissions</h2>
       <table>
         <thead>
@@ -27,33 +40,43 @@ export default function ReviewSubmissions() {
           </tr>
         </thead>
         <tbody>
-          {subs.map((s, i) => (
-            <tr key={s.id}>
-              <td>{s.name}</td>
-              <td>
-                <a href={s.file_url} target="_blank" rel="noopener noreferrer">
-                  Download
-                </a>
-              </td>
-              <td>
-                <input
-                  type="number"
-                  value={s.grade ?? ''}
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    setSubs((prev) => {
-                      const copy = [...prev];
-                      copy[i] = { ...copy[i], grade: val };
-                      return copy;
-                    });
-                  }}
-                />
-              </td>
-              <td>
-                <button onClick={() => updateGrade(s.id, s.grade)}>✅</button>
-              </td>
-            </tr>
-          ))}
+          {subs.map((s, i) => {
+            const modified = s.grade !== s.originalGrade;
+            return (
+              <tr key={s.id}>
+                <td>{s.name}</td>
+                <td>
+                  {s.file_url.split('/').pop()}{' '}
+                  <a href={s.file_url} download style={{ marginLeft: '4px' }}>
+                    ⬇️
+                  </a>
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    value={s.grade ?? ''}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      setSubs((prev) => {
+                        const copy = [...prev];
+                        copy[i] = { ...copy[i], grade: val };
+                        return copy;
+                      });
+                    }}
+                  />
+                </td>
+                <td>
+                  <button
+                    className={modified ? 'text-green-600' : 'text-gray-400'}
+                    disabled={!modified}
+                    onClick={() => updateGrade(s.id, s.grade, i)}
+                  >
+                    ✔️
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/myapp/frontend/src/pages/SubjectDetail.jsx
+++ b/myapp/frontend/src/pages/SubjectDetail.jsx
@@ -4,7 +4,7 @@ import api from '../api';
 import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
 
-function UploadButton({ resourceId }) {
+function UploadButton({ resourceId, label = 'Submit', disabled = false }) {
   const inputRef = useRef();
   const handleUpload = (e) => {
     const file = e.target.files[0];
@@ -18,8 +18,12 @@ function UploadButton({ resourceId }) {
   };
   return (
     <>
-      <button onClick={() => inputRef.current && inputRef.current.click()} style={{ marginLeft: '8px' }}>
-        Submit
+      <button
+        disabled={disabled}
+        onClick={() => !disabled && inputRef.current && inputRef.current.click()}
+        style={{ marginLeft: '8px' }}
+      >
+        {label}
       </button>
       <input type="file" ref={inputRef} onChange={handleUpload} style={{ display: 'none' }} />
     </>
@@ -72,16 +76,43 @@ export default function SubjectDetail() {
       <ul>
         {resources.map((r) => {
           const showDue = r.due_date ? ` (Due: ${new Date(r.due_date).toLocaleDateString()})` : '';
+          const duePassed = r.due_date && new Date() > new Date(r.due_date);
+          const submission = r.submissions && r.submissions[0];
           return (
             <li key={r.id} style={{ marginBottom: '8px' }}>
               {r.title} ({r.type}){showDue}
+              {role === 'professor' && r.type === 'practice' && (
+                <button onClick={() => alert('TODO')} style={{ marginLeft: '8px' }}>
+                  Edit
+                </button>
+              )}
               {role === 'student' && r.type === 'exercise' && (
-                <UploadButton resourceId={r.id} />
+                <>
+                  {submission && (
+                    <div>
+                      📎 {submission.file_path.split('/').pop()}
+                      {submission.grade != null && <span> - {submission.grade}</span>}
+                    </div>
+                  )}
+                  <UploadButton
+                    resourceId={r.id}
+                    label={submission ? 'Edit delivery' : 'Submit'}
+                    disabled={duePassed}
+                  />
+                  {duePassed && <span style={{ marginLeft: '8px' }}>Past due date</span>}
+                </>
               )}
               {role === 'student' && r.type === 'practice' && (
-                <button onClick={() => alert('TODO')} style={{ marginLeft: '8px' }}>
-                  Start
-                </button>
+                <>
+                  <button
+                    disabled={duePassed}
+                    onClick={() => alert('TODO')}
+                    style={{ marginLeft: '8px' }}
+                  >
+                    Start
+                  </button>
+                  {duePassed && <span style={{ marginLeft: '8px' }}>Past due date</span>}
+                </>
               )}
               {role === 'professor' && r.type === 'exercise' && (
                 <button


### PR DESCRIPTION
## Summary
- add back button in ReviewSubmissions and handle grade editing
- show file names with download icon
- allow grade inputs to enable/disable save button depending on modifications
- enhance SubjectDetail with edit buttons and submission details
- disable actions after due date

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669add4b3083218bc4eb24119509c8