### PR TITLE
Improve resources review and details

### DIFF
--- a/myapp/frontend/src/pages/ReviewSubmissions.js
+++ b/myapp/frontend/src/pages/ReviewSubmissions.js
@@ -1,21 +1,41 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import api from '../api';
 
 export default function ReviewSubmissions() {
   const { id } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const code = location.state?.code;
   const [subs, setSubs] = useState([]);
 
   useEffect(() => {
-    api.get(`/resources/${id}/submissions`).then((res) => setSubs(res.data));
+    api
+      .get(`/resources/${id}/submissions`)
+      .then((res) =>
+        setSubs(res.data.map((s) => ({ ...s, originalGrade: s.grade })))
+      );
   }, [id]);
 
-  const updateGrade = async (sid, grade) => {
+  const updateGrade = async (sid, grade, index) => {
     await api.patch(`/submissions/${sid}`, { grade });
+    setSubs((prev) => {
+      const copy = [...prev];
+      copy[index] = { ...copy[index], originalGrade: grade };
+      return copy;
+    });
   };
 
   return (
     <div>
+      <button
+        onClick={() =>
+          code ? navigate(`/subjects/${code}`) : navigate(-1)
+        }
+        style={{ marginBottom: '16px' }}
+      >
+        ← Volver a Asignatura
+      </button>
       <h2>Submissions</h2>
       <table>
         <thead>
@@ -27,33 +47,49 @@ export default function ReviewSubmissions() {
           </tr>
         </thead>
         <tbody>
-          {subs.map((s, i) => (
-            <tr key={s.id}>
-              <td>{s.name}</td>
-              <td>
-                <a href={s.file_url} target="_blank" rel="noopener noreferrer">
-                  Download
-                </a>
-              </td>
-              <td>
-                <input
-                  type="number"
-                  value={s.grade ?? ''}
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    setSubs((prev) => {
-                      const copy = [...prev];
-                      copy[i] = { ...copy[i], grade: val };
-                      return copy;
-                    });
-                  }}
-                />
-              </td>
-              <td>
-                <button onClick={() => updateGrade(s.id, s.grade)}>✅</button>
-              </td>
-            </tr>
-          ))}
+          {subs.map((s, i) => {
+            const modified = s.grade !== s.originalGrade;
+            return (
+              <tr key={s.id}>
+                <td>{s.name}</td>
+                <td>
+                  {s.file_url.split(/[/\\]/).pop()}{' '}
+                  <a
+                    href={`${api.defaults.baseURL.replace(/\/api$/, '')}${s.file_url}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    download
+                    style={{ marginLeft: '4px' }}
+                  >
+                    ⬇️
+                  </a>
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    value={s.grade ?? ''}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      setSubs((prev) => {
+                        const copy = [...prev];
+                        copy[i] = { ...copy[i], grade: val };
+                        return copy;
+                      });
+                    }}
+                  />
+                </td>
+                <td>
+                  <button
+                    className={modified ? 'text-green-600' : 'text-gray-400'}
+                    disabled={!modified}
+                    onClick={() => updateGrade(s.id, s.grade, i)}
+                  >
+                    ✔️
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- fix navigation to subject detail by passing subject code in state
- show clean filenames using both slash styles and provide working download links
- handle file submissions with grade display in subject details

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68669add4b3083218bc4eb24119509c8