### PR TITLE
Fix download link to use backend URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/__pycache__/
 **/*.pyc
 **/.env
+!.env
 node_modules
 dist
 .git

--- a/myapp/frontend/src/pages/ReviewSubmissions.js
+++ b/myapp/frontend/src/pages/ReviewSubmissions.js
@@ -61,7 +61,7 @@ export default function ReviewSubmissions() {
                 <td className="border px-2 py-1">
                   {fileName}{' '}
                   <a
-                    href={s.file_url}
+                    href={`${import.meta.env.VITE_API_URL}${s.file_url}`}
                     download
                     className="text-blue-600 hover:underline ml-1"
                   >


### PR DESCRIPTION
## Summary
- ensure `.env` file with `VITE_API_URL`
- adjust gitignore so `.env` is tracked
- prefix submission download links with backend URL

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867adbc283c8321810f491705a8f65c