### PR TITLE
Fix download links to use backend URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_API_URL=http://localhost:5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 **/__pycache__/
 **/*.pyc
 **/.env
-!.env
 node_modules
 dist
 .git

--- a/myapp/frontend/src/api.js
+++ b/myapp/frontend/src/api.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
+export const BACKEND_URL = 'http://localhost:5000';
 //const api = axios.create({ baseURL: '/api' });
-const api = axios.create({ baseURL: 'http://localhost:5000/api' });
+const api = axios.create({ baseURL: `${BACKEND_URL}/api` });
 
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('token');

--- a/myapp/frontend/src/pages/ReviewSubmissions.js
+++ b/myapp/frontend/src/pages/ReviewSubmissions.js
@@ -1,7 +1,7 @@
 // src/pages/ReviewSubmissions.jsx
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import api from '../api';
+import api, { BACKEND_URL } from '../api';
 
 export default function ReviewSubmissions() {
   const { code, id } = useParams();
@@ -61,7 +61,7 @@ export default function ReviewSubmissions() {
                 <td className="border px-2 py-1">
                   {fileName}{' '}
                   <a
-                    href={`${import.meta.env.VITE_API_URL}${s.file_url}`}
+                    href={`${BACKEND_URL}${s.file_url}`}
                     download
                     className="text-blue-600 hover:underline ml-1"
                   >


### PR DESCRIPTION
## Summary
- centralize backend URL in `src/api.js`
- use `BACKEND_URL` when building download links
- delete obsolete `.env` file and ignore it
- rebuild frontend

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867afb6f3c08321a077f3436807a5ac