### PR TITLE
Add 401 redirect interceptor

### DIFF
--- a/myapp/frontend/src/api.js
+++ b/myapp/frontend/src/api.js
@@ -12,4 +12,16 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// Redirect to login on 401 errors
+api.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err.response && err.response.status === 401) {
+      localStorage.clear();
+      window.location.href = '/login';
+    }
+    return Promise.reject(err);
+  }
+);
+
 export default api;


### PR DESCRIPTION
## Summary
- add a global axios response interceptor that redirects to `/login` when the backend returns a 401

## Testing
- `npm test --silent` *(fails: no test script configured)*

------
https://chatgpt.com/codex/tasks/task_e_6867b1c9cfe08321bd60ee875884b947