### PR TITLE
Improve exercise submission UX

### DIFF
--- a/myapp/frontend/src/icons/DefaultFileIcon.jsx
+++ b/myapp/frontend/src/icons/DefaultFileIcon.jsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function DefaultFileIcon() {
+  return <span role="img" aria-label="File">📁</span>;
+}

--- a/myapp/frontend/src/icons/ImageIcon.jsx
+++ b/myapp/frontend/src/icons/ImageIcon.jsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function ImageIcon() {
+  return <span role="img" aria-label="Image">🖼️</span>;
+}

--- a/myapp/frontend/src/icons/PdfIcon.jsx
+++ b/myapp/frontend/src/icons/PdfIcon.jsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function PdfIcon() {
+  return <span role="img" aria-label="PDF">📄</span>;
+}

--- a/myapp/frontend/src/icons/WordIcon.jsx
+++ b/myapp/frontend/src/icons/WordIcon.jsx
@@ -1,0 +1,4 @@
+import React from 'react';
+export default function WordIcon() {
+  return <span role="img" aria-label="Word">📄</span>;
+}

--- a/myapp/frontend/src/pages/SubjectDetail.jsx
+++ b/myapp/frontend/src/pages/SubjectDetail.jsx
@@ -3,8 +3,12 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import api from '../api';
 import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
+import PdfIcon from '../icons/PdfIcon';
+import ImageIcon from '../icons/ImageIcon';
+import WordIcon from '../icons/WordIcon';
+import DefaultFileIcon from '../icons/DefaultFileIcon';
 
-function UploadButton({ resourceId, label = 'Submit', disabled = false }) {
+function UploadButton({ resourceId, label = 'Submit', disabled = false, onUploaded }) {
   const inputRef = useRef();
   const handleUpload = (e) => {
     const file = e.target.files[0];
@@ -13,7 +17,10 @@ function UploadButton({ resourceId, label = 'Submit', disabled = false }) {
     fd.append('file', file);
     api
       .post(`/resources/${resourceId}/submit`, fd)
-      .then(() => alert('Submitted successfully'))
+      .then(() => {
+        alert('Submitted successfully');
+        if (onUploaded) onUploaded();
+      })
       .catch(() => alert('Error submitting'));
   };
   return (
@@ -35,6 +42,13 @@ export default function SubjectDetail() {
   const [subject, setSubject] = useState(null);
   const [resources, setResources] = useState([]);
   const navigate = useNavigate();
+
+  const fetchResources = () => {
+    api
+      .get(`/subjects/${code}/resources`)
+      .then((res) => setResources(res.data))
+      .catch(() => {});
+  };
   
   useEffect(() => {
     let isMounted = true;
@@ -44,10 +58,9 @@ export default function SubjectDetail() {
       .then((data) => isMounted && setSubject(data))
       .catch(() => {});
 
-    api
-      .get(`/subjects/${code}/resources`)
-      .then((res) => isMounted && setResources(res.data))
-      .catch(() => {});
+    if (isMounted) {
+      fetchResources();
+    }
 
     return () => {
       isMounted = false;
@@ -77,7 +90,7 @@ export default function SubjectDetail() {
         {resources.map((r) => {
           const showDue = r.due_date ? ` (Due: ${new Date(r.due_date).toLocaleDateString()})` : '';
           const duePassed = r.due_date && new Date() > new Date(r.due_date);
-          const submission = r.submissions && r.submissions[0];
+          const currentSubmission = r.submissions && r.submissions[0];
           return (
             <li key={r.id} style={{ marginBottom: '8px' }}>
               {r.title} ({r.type}){showDue}
@@ -88,18 +101,59 @@ export default function SubjectDetail() {
               )}
               {role === 'student' && r.type === 'exercise' && (
                 <>
-                  {submission && (
-                    <div>
-                      📎 {submission.file_path.split(/[/\\]/).pop()}
-                      {submission.grade != null && <span> - {submission.grade}</span>}
+                  {currentSubmission ? (
+                    <div className="mt-2 p-2 border rounded flex items-center space-x-4">
+                      {(() => {
+                        const ext = currentSubmission.file_path.split('.').pop().toLowerCase();
+                        switch (ext) {
+                          case 'pdf':
+                            return <PdfIcon />;
+                          case 'png':
+                          case 'jpg':
+                          case 'jpeg':
+                            return <ImageIcon />;
+                          case 'doc':
+                          case 'docx':
+                            return <WordIcon />;
+                          default:
+                            return <DefaultFileIcon />;
+                        }
+                      })()}
+                      <div>
+                        <div className="font-medium">
+                          {currentSubmission.file_path.split(/[/\\]/).pop()}
+                        </div>
+                        {currentSubmission.grade != null && (
+                          <div className="text-sm text-gray-600">Grade: {currentSubmission.grade}</div>
+                        )}
+                      </div>
+                      <div className="ml-auto space-x-2">
+                        <UploadButton
+                          resourceId={r.id}
+                          label="Edit Delivery"
+                          disabled={duePassed}
+                          onUploaded={fetchResources}
+                        />
+                        <button
+                          onClick={async () => {
+                            await api.delete(`/submissions/${currentSubmission.id}`);
+                            fetchResources();
+                          }}
+                          className="px-2 py-1 bg-red-500 text-white rounded hover:bg-red-600"
+                        >
+                          Remove Submission
+                        </button>
+                      </div>
                     </div>
+                  ) : (
+                    <UploadButton
+                      resourceId={r.id}
+                      label="Submit"
+                      disabled={duePassed}
+                      onUploaded={fetchResources}
+                    />
                   )}
-                  <UploadButton
-                    resourceId={r.id}
-                    label={submission ? 'Edit delivery' : 'Submit'}
-                    disabled={duePassed}
-                  />
-                  {duePassed && <span style={{ marginLeft: '8px' }}>Past due date</span>}
+                  {duePassed && <span className="ml-2 text-red-600">Past due date</span>}
                 </>
               )}
               {role === 'student' && r.type === 'practice' && (


### PR DESCRIPTION
## Summary
- update SubjectDetail page to show submission info and edit/remove controls
- refresh resources after uploading or removing a submission
- add simple file icon components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867be266fc4832193292caa93158e09