### PR TITLE
Add resource detail page

### DIFF
--- a/myapp/backend/routes/resources.py
+++ b/myapp/backend/routes/resources.py
@@ -27,6 +27,26 @@ def _student_required():
     return None
 
 
+@bp.route('/resources/<rid>', methods=['GET'])
+@jwt_required()
+def get_resource(rid):
+    """Return full information about a resource"""
+    mongo = get_db()
+    res = mongo.db.resources.find_one({'_id': ObjectId(rid)})
+    if not res:
+        return jsonify({'error': 'Not found'}), 404
+
+    result = {
+        'id': str(res['_id']),
+        'subject_code': res.get('subject_code'),
+        'title': res.get('title'),
+        'type': res.get('type'),
+        'description': res.get('description'),
+        'due_date': res.get('due_date'),
+    }
+    return jsonify(result)
+
+
 @bp.route('/resources/<rid>', methods=['PUT'])
 @jwt_required()
 def update_resource(rid):

--- a/myapp/frontend/src/index.js
+++ b/myapp/frontend/src/index.js
@@ -15,6 +15,7 @@ import SubjectDetail from './pages/SubjectDetail';
 import NewResource from './pages/NewResource';
 import PrivateRoute from './PrivateRoute';
 import ReviewSubmissions from './pages/ReviewSubmissions';
+import ResourceDetail from './pages/ResourceDetail';
 
 function App() {
   return (
@@ -45,6 +46,15 @@ function App() {
           element={
             <PrivateRoute>
               <NewResource />
+            </PrivateRoute>
+          }
+        />
+
+        <Route
+          path="/resources/:id"
+          element={
+            <PrivateRoute>
+              <ResourceDetail />
             </PrivateRoute>
           }
         />

--- a/myapp/frontend/src/pages/ResourceDetail.jsx
+++ b/myapp/frontend/src/pages/ResourceDetail.jsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import api from '../api';
+import PdfIcon from '../icons/PdfIcon';
+import ImageIcon from '../icons/ImageIcon';
+import WordIcon from '../icons/WordIcon';
+import DefaultFileIcon from '../icons/DefaultFileIcon';
+
+function UploadButton({ resourceId, label = 'Submit', disabled = false, onUploaded }) {
+  const inputRef = useRef();
+  const handleUpload = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    api
+      .post(`/resources/${resourceId}/submit`, fd)
+      .then(() => {
+        alert('Submitted successfully');
+        if (onUploaded) onUploaded();
+      })
+      .catch(() => alert('Error submitting'));
+  };
+  return (
+    <>
+      <button
+        disabled={disabled}
+        onClick={() => !disabled && inputRef.current && inputRef.current.click()}
+        style={{ marginLeft: '8px' }}
+      >
+        {label}
+      </button>
+      <input type="file" ref={inputRef} onChange={handleUpload} style={{ display: 'none' }} />
+    </>
+  );
+}
+
+export default function ResourceDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [resource, setResource] = useState(null);
+  const [submission, setSubmission] = useState(null);
+
+  const fetchSubmission = async () => {
+    try {
+      const res = await api.get(`/resources/${id}/submission`);
+      setSubmission(res.data);
+    } catch (e) {
+      setSubmission(null);
+    }
+  };
+
+  useEffect(() => {
+    api.get(`/resources/${id}`)
+      .then((res) => setResource(res.data))
+      .catch(console.error);
+    fetchSubmission();
+  }, [id]);
+
+  if (!resource) return <div>Loading...</div>;
+
+  const role = localStorage.getItem('role');
+  const duePassed = resource.due_date && new Date() > new Date(resource.due_date);
+
+  return (
+    <div>
+      <button
+        onClick={() => navigate(`/subjects/${resource.subject_code}`)}
+        style={{ marginBottom: '16px' }}
+      >
+        ← Back to Subject
+      </button>
+
+      <h2>{resource.title}</h2>
+      <p>{resource.description}</p>
+      {resource.due_date && (
+        <p>Due: {new Date(resource.due_date).toLocaleString()}</p>
+      )}
+      {submission && submission.grade != null && (
+        <p>Grade: {submission.grade}</p>
+      )}
+
+      {/* Student actions */}
+      {role === 'student' && resource.type === 'exercise' && (
+        <div style={{ marginTop: '8px' }}>
+          {submission ? (
+            !duePassed && (
+              <>
+                <UploadButton
+                  resourceId={id}
+                  label="Edit Delivery"
+                  onUploaded={fetchSubmission}
+                />
+                <button
+                  onClick={async () => {
+                    await api.delete(`/submissions/${submission.id}`);
+                    fetchSubmission();
+                  }}
+                  className="px-2 py-1 bg-red-500 text-white rounded hover:bg-red-600"
+                >
+                  Remove Submission
+                </button>
+              </>
+            )
+          ) : (
+            <UploadButton
+              resourceId={id}
+              label="Submit"
+              disabled={duePassed}
+              onUploaded={fetchSubmission}
+            />
+          )}
+        </div>
+      )}
+
+      {role === 'student' && resource.type === 'practice' && (
+        <button disabled={duePassed} onClick={() => alert('TODO')} style={{ marginTop: '8px' }}>
+          Start
+        </button>
+      )}
+
+      {/* File info */}
+      {submission && (
+        <div
+          style={{
+            marginTop: '16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+          }}
+        >
+          {(() => {
+            const ext = submission.file_url.split('.').pop().toLowerCase();
+            switch (ext) {
+              case 'pdf':
+                return <PdfIcon />;
+              case 'png':
+              case 'jpg':
+              case 'jpeg':
+                return <ImageIcon />;
+              case 'doc':
+              case 'docx':
+                return <WordIcon />;
+              default:
+                return <DefaultFileIcon />;
+            }
+          })()}
+          <span>{submission.file_url.split(/[/\\]/).pop()}</span>
+        </div>
+      )}
+
+      {duePassed && !submission && (
+        <div className="mt-1 text-red-600">Past due date</div>
+      )}
+
+      {/* Professor review button */}
+      {role === 'professor' && resource.type === 'exercise' && (
+        <button
+          onClick={() =>
+            navigate(`/resources/${id}/review`, {
+              state: { code: resource.subject_code, title: resource.title },
+            })
+          }
+          style={{ marginTop: '8px' }}
+        >
+          Revisar
+        </button>
+      )}
+    </div>
+  );
+}

--- a/myapp/frontend/src/pages/SubjectDetail.jsx
+++ b/myapp/frontend/src/pages/SubjectDetail.jsx
@@ -1,43 +1,11 @@
 // src/pages/SubjectDetail.jsx
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import api from '../api';
 import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
-import PdfIcon from '../icons/PdfIcon';
-import ImageIcon from '../icons/ImageIcon';
-import WordIcon from '../icons/WordIcon';
-import DefaultFileIcon from '../icons/DefaultFileIcon';
 
-function UploadButton({ resourceId, label = 'Submit', disabled = false, onUploaded }) {
-  const inputRef = useRef();
-  const handleUpload = (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-    const fd = new FormData();
-    fd.append('file', file);
-    api
-      .post(`/resources/${resourceId}/submit`, fd)
-      .then(() => {
-        alert('Submitted successfully');
-        if (onUploaded) onUploaded();
-      })
-      .catch(() => alert('Error submitting'));
-  };
-  return (
-    <>
-      <button
-        disabled={disabled}
-        onClick={() => !disabled && inputRef.current && inputRef.current.click()}
-        style={{ marginLeft: '8px' }}
-      >
-        {label}
-      </button>
-      <input type="file" ref={inputRef} onChange={handleUpload} style={{ display: 'none' }} />
-    </>
-  );
-}
 
 export default function SubjectDetail() {
   const { code } = useParams();
@@ -130,150 +98,10 @@ export default function SubjectDetail() {
           const showDue = r.due_date
             ? ` (Due: ${new Date(r.due_date).toLocaleString()})`
             : '';
-          const duePassed = r.due_date && new Date() > new Date(r.due_date);
-          const currentSubmission = r.submissions && r.submissions[0];
-
-          // Caso: estudiante y recurso de tipo exercise
-if (role === 'student' && r.type === 'exercise') {
-  return (
-    <li key={r.id} style={{ marginBottom: '16px' }}>
-      {/* Línea 1: título + botones */}
-      <div
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '12px',
-          marginBottom: '4px',
-        }}
-      >
-        <span>
-          {r.title} (exercise){showDue}
-        </span>
-
-        {currentSubmission ? (
-          !duePassed && (
-            <>
-              <UploadButton
-                resourceId={r.id}
-                label="Edit Delivery"
-                onUploaded={fetchResources}
-              />
-              <button
-                onClick={async () => {
-                  await api.delete(`/submissions/${currentSubmission.id}`);
-                  fetchResources();
-                }}
-                className="px-2 py-1 bg-red-500 text-white rounded hover:bg-red-600"
-              >
-                Remove Submission
-              </button>
-            </>
-          )
-        ) : (
-          <UploadButton
-            resourceId={r.id}
-            label="Submit"
-            disabled={duePassed}
-            onUploaded={fetchResources}
-          />
-        )}
-      </div>
-
-      {/* Línea 2: icono + nombre + nota */}
-      {currentSubmission && (
-        <div
-          style={{
-            marginLeft: '24px',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-          }}
-        >
-          {/* Icono según extensión */}
-          {(() => {
-            const ext = currentSubmission.file_url
-              .split('.')
-              .pop()
-              .toLowerCase();
-            switch (ext) {
-              case 'pdf':
-                return <PdfIcon />;
-              case 'png':
-              case 'jpg':
-              case 'jpeg':
-                return <ImageIcon />;
-              case 'doc':
-              case 'docx':
-                return <WordIcon />;
-              default:
-                return <DefaultFileIcon />;
-            }
-          })()}
-
-          {/* Nombre limpio */}
-          <span>
-            {currentSubmission.file_url.split(/[/\\]/).pop()}
-          </span>
-
-          {/* Nota */}
-          {currentSubmission.grade != null && (
-            <span className="text-sm text-gray-600">
-              Grade: {currentSubmission.grade}
-            </span>
-          )}
-        </div>
-      )}
-
-      {/* Past due date si aplica */}
-      {duePassed && !currentSubmission && (
-        <div className="mt-1 text-red-600">Past due date</div>
-      )}
-    </li>
-  );
-}
-
-
-          // Otros casos (profesor, práctica, lecture...)
           return (
             <li key={r.id} style={{ marginBottom: '8px' }}>
-              {r.title} ({r.type})
+              <Link to={`/resources/${r.id}`}>{r.title} ({r.type})</Link>
               {showDue}
-              {role === 'professor' && r.type === 'practice' && (
-                <button
-                  onClick={() => alert('TODO')}
-                  style={{ marginLeft: '8px' }}
-                >
-                  Edit
-                </button>
-              )}
-              {role === 'student' && r.type === 'practice' && (
-                <>
-                  <button
-                    disabled={duePassed}
-                    onClick={() => alert('TODO')}
-                    style={{ marginLeft: '8px' }}
-                  >
-                    Start
-                  </button>
-                  {duePassed && (
-                    <span style={{ marginLeft: '8px' }}>
-                      Past due date
-                    </span>
-                  )}
-                </>
-              )}
-              {role === 'professor' && r.type === 'exercise' && (
-                <button
-                  onClick={() =>
-                    navigate(`/resources/${r.id}/review`, {
-                      state: { code: subject.code, title: subject.title },
-                    })
-                  }
-                  style={{ marginLeft: '8px' }}
-                >
-                  Revisar
-                </button>
-              )}
             </li>
           );
         })}


### PR DESCRIPTION
## Summary
- allow fetching full resource detail through backend
- add ResourceDetail page in frontend
- simplify SubjectDetail resource listing
- link to ResourceDetail in router

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686b9a58d08883219dd7d051be129093