### PR TITLE
Add submissions info to subject detail

### DIFF
--- a/myapp/frontend/src/pages/SubjectDetail.jsx
+++ b/myapp/frontend/src/pages/SubjectDetail.jsx
@@ -98,10 +98,20 @@ export default function SubjectDetail() {
           const showDue = r.due_date
             ? ` (Due: ${new Date(r.due_date).toLocaleString()})`
             : '';
+          const showCounts =
+            role === 'professor' && r.type === 'exercise' && r.submissions_count != null;
           return (
             <li key={r.id} style={{ marginBottom: '8px' }}>
               <Link to={`/resources/${r.id}`}>{r.title} ({r.type})</Link>
               {showDue}
+              {showCounts && (
+                <>
+                  {' '}- {r.submissions_count} submissions
+                  {r.has_ungraded && (
+                    <span className="text-red-600 ml-1">⚠️ pendientes</span>
+                  )}
+                </>
+              )}
             </li>
           );
         })}


### PR DESCRIPTION
## Summary
- show number of submissions and pending grade status for each exercise
- build frontend to render this data

## Testing
- `npm install`
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b9d1e043083219187908ed5ca5a10