### PR TITLE
Add calendar agenda to SubjectDetail

### DIFF
--- a/myapp/frontend/src/components/CalendarAgenda.jsx
+++ b/myapp/frontend/src/components/CalendarAgenda.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 function CalendarAgenda({ resources }) {
   const events = resources
     .filter((r) => r.due_date)
-    .map((r) => ({ date: new Date(r.due_date), title: r.title }))
+    .map((r) => ({ id: r.id, date: new Date(r.due_date), title: r.title }))
     .sort((a, b) => a.date - b.date);
 
   return (
@@ -11,7 +12,9 @@ function CalendarAgenda({ resources }) {
       <ul>
         {events.map((event, idx) => (
           <li key={idx} style={{ marginBottom: '4px' }}>
-            {event.date.toLocaleDateString()} {event.date.toLocaleTimeString()} - {event.title}
+            <Link to={`/resources/${event.id}`}>
+              {event.date.toLocaleDateString()} {event.date.toLocaleTimeString()} - {event.title}
+            </Link>
           </li>
         ))}
       </ul>

--- a/myapp/frontend/src/components/CalendarAgenda.jsx
+++ b/myapp/frontend/src/components/CalendarAgenda.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+function CalendarAgenda({ resources }) {
+  const events = resources
+    .filter((r) => r.due_date)
+    .map((r) => ({ date: new Date(r.due_date), title: r.title }))
+    .sort((a, b) => a.date - b.date);
+
+  return (
+    <div style={{ maxHeight: '300px', overflowY: 'auto' }}>
+      <ul>
+        {events.map((event, idx) => (
+          <li key={idx} style={{ marginBottom: '4px' }}>
+            {event.date.toLocaleDateString()} {event.date.toLocaleTimeString()} - {event.title}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default CalendarAgenda;

--- a/myapp/frontend/src/pages/SubjectDetail.jsx
+++ b/myapp/frontend/src/pages/SubjectDetail.jsx
@@ -5,6 +5,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import api from '../api';
 import { CircularProgressbar } from 'react-circular-progressbar';
 import 'react-circular-progressbar/dist/styles.css';
+import CalendarAgenda from '../components/CalendarAgenda';
 
 
 export default function SubjectDetail() {
@@ -97,6 +98,8 @@ export default function SubjectDetail() {
       </div>
 
       <h3>Resources</h3>
+      <h3 className="text-xl mb-2">Agenda</h3>
+      <CalendarAgenda resources={resources} />
       <ul>
         {resources.map((r) => {
           const showDue = r.due_date


### PR DESCRIPTION
## Summary
- add new `CalendarAgenda` component that lists resources with due dates
- show agenda below the resources heading on SubjectDetail page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686f812ac7088321867de708217e0c53