### PR TITLE
Implement lecture file attachments

### DIFF
--- a/myapp/frontend/src/pages/SubjectDetail.jsx
+++ b/myapp/frontend/src/pages/SubjectDetail.jsx
@@ -114,7 +114,12 @@ export default function SubjectDetail() {
             (!r.submissions || r.submissions.length === 0);
           return (
             <li key={r.id} style={{ marginBottom: '8px' }}>
-              <Link to={`/resources/${r.id}`}>{r.title} ({r.type})</Link>
+              <Link
+                to={`/resources/${r.id}`}
+                state={{ subjectTitle: subject.title }}
+              >
+                {r.title} ({r.type})
+              </Link>
               {showDue}
               {showPendingSubmission && (
                 <span className="text-red-600 ml-1">⚠️ submission pending</span>


### PR DESCRIPTION
## Summary
- include attachments in resource info
- allow professors to upload/delete lecture attachments
- show lecture attachments in resource page
- pass subject title when linking to resource

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8e2c58ec832188b6e4f96a1590e8