### PR TITLE
Support multiple lecture attachments upload

### DIFF
--- a/myapp/backend/API_DOC.md
+++ b/myapp/backend/API_DOC.md
@@ -63,6 +63,15 @@ Permite a un profesor eliminar un recurso.
 
 - **Auth:** JWT requerido (rol: profesor)
 
+### `POST /resources/<rid>/attachments`
+
+Sube uno o varios archivos adjuntos para un recurso tipo "lecture".
+
+- **Auth:** JWT requerido (rol: profesor)
+- **FormData:** `files` (puede incluir varios archivos)
+- **Response:** Lista de objetos `{ "file_url": str, "filename": str }`
+- **Límite:** Máximo 10 archivos por recurso.
+
 ---
 
 ## Entregas (Submissions)

--- a/myapp/frontend/src/pages/ResourceDetail.jsx
+++ b/myapp/frontend/src/pages/ResourceDetail.jsx
@@ -98,13 +98,14 @@ export default function ResourceDetail() {
           {role === 'professor' && (
             <input
               type="file"
+              multiple
               onChange={async (e) => {
-                const file = e.target.files[0];
-                if (!file) return;
+                const files = Array.from(e.target.files);
+                if (!files.length) return;
                 const fd = new FormData();
-                fd.append('file', file);
+                files.forEach((f) => fd.append('files', f));
                 const res = await api.post(`/resources/${id}/attachments`, fd);
-                setAttachments((prev) => [...prev, res.data]);
+                setAttachments((prev) => [...prev, ...(res.data || [])]);
                 e.target.value = '';
               }}
               disabled={attachments.length >= 10}


### PR DESCRIPTION
## Summary
- allow uploading multiple files at once for lecture attachments
- update frontend to send multiple files
- document new `/resources/<rid>/attachments` endpoint

## Testing
- `python -m py_compile myapp/backend/routes/resources.py`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686f90c64e408321a8142f0b6c3e86b7