### PR TITLE
Move practice actions to resource detail

### DIFF
--- a/myapp/frontend/src/pages/ResourceDetail.jsx
+++ b/myapp/frontend/src/pages/ResourceDetail.jsx
@@ -181,6 +181,23 @@ export default function ResourceDetail() {
         </button>
       )}
 
+      {role === 'professor' && resource.type === 'practice' && (
+        <button
+          onClick={async () => {
+            const url = prompt('Implementation URL');
+            if (url) {
+              await api.put(`/resources/${id}/implementation_link`, {
+                practice_external_url: url,
+              });
+            }
+          }}
+          className="ml-2 px-2 py-1 bg-blue-500 text-white rounded"
+          style={{ marginTop: '8px' }}
+        >
+          Implement
+        </button>
+      )}
+
       {/* File info */}
       {submission && (
         <div

--- a/myapp/frontend/src/pages/SubjectDetail.jsx
+++ b/myapp/frontend/src/pages/SubjectDetail.jsx
@@ -180,29 +180,7 @@ export default function SubjectDetail() {
                   )}
                 </>
               )}
-              {role === 'student' && isPractice && (
-                <button
-                  onClick={() => navigate(`/subjects/${code}/practices/${r.id}`)}
-                  className="ml-2 px-2 py-1 bg-green-500 text-white rounded"
-                >
-                  Start
-                </button>
-              )}
-              {role === 'professor' && isPractice && (
-                <button
-                  onClick={async () => {
-                    const url = prompt('Implementation URL');
-                    if (url) {
-                      await api.put(`/resources/${r.id}/implementation_link`, {
-                        practice_external_url: url,
-                      });
-                    }
-                  }}
-                  className="ml-2 px-2 py-1 bg-blue-500 text-white rounded"
-                >
-                  Implement
-                </button>
-              )}
+              {/* Practice actions moved to ResourceDetail */}
             </li>
           );
         })}


### PR DESCRIPTION
## Summary
- keep practice Start/Implement buttons inside ResourceDetail
- remove practice actions from SubjectDetail

## Testing
- `npm run build`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68701d2ea9448321adf0aed9753addb4