### PR TITLE
Use sender to choose chat avatars

### DIFF
--- a/myapp/frontend/src/components/ChatPractice.jsx
+++ b/myapp/frontend/src/components/ChatPractice.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import dayjs from 'dayjs';
 import api from '../api';
+import sophiaImg from '../icons/sophia.png';
+import userImg from '../icons/user_generic.png';
 
 export default function ChatPractice({ practiceId }) {
   const [messages, setMessages] = useState([]);
@@ -72,11 +74,16 @@ export default function ChatPractice({ practiceId }) {
       <div className="flex flex-col gap-3 overflow-y-auto grow px-4 py-2" ref={scrollRef}>
         {messages.map((m, i) => {
           const mine = m.sender === 'student';
+          const avatarSrc = m.sender === 'sophia' ? sophiaImg : userImg;
           return (
             <div key={i} className={`flex ${mine ? 'justify-end' : 'justify-start'}`}>
               <div>
                 {/* avatar */}
-                <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${mine ? 'bg-purple-500 text-white' : 'bg-blue-500 text-white'}`}>{mine ? 'Y' : 'S'}</div>
+                <img
+                  src={avatarSrc}
+                  alt={m.sender === 'sophia' ? 'SophIA avatar' : 'User avatar'}
+                  className="w-6 h-6 rounded-full"
+                />
               </div>
               <div className={`ml-2 flex flex-col items-${mine ? 'end' : 'start'}`}>
                 <div className={`${mine ? 'bg-blue-600 text-white' : 'bg-gray-100'} rounded-xl ${mine ? 'rounded-tr-none' : 'rounded-tl-none'} px-4 py-2 max-w-[70%]`}>


### PR DESCRIPTION
## Summary
- in the practice chat, decide which avatar image to show based on each message's `sender`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68702d2feb808321b0341ac8914d0d25