### PR TITLE
Implement navbar with breadcrumb and layout

### DIFF
--- a/myapp/frontend/src/components/Navbar.jsx
+++ b/myapp/frontend/src/components/Navbar.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+
+export default function Navbar() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // Hide navbar on login page
+  if (location.pathname === '/login') return null;
+
+  const parts = location.pathname.split('/').filter(Boolean);
+  const crumbs = [{ text: 'Dashboard', to: '/dashboard' }];
+
+  if (parts[0] === 'subjects' && parts[1]) {
+    const subjectCode = parts[1];
+    const subjectTitle = localStorage.getItem(`subj_title_${subjectCode}`) || subjectCode;
+    crumbs.push({ text: subjectTitle, to: `/subjects/${subjectCode}` });
+
+    if (parts[2]) {
+      const resId = parts[2] === 'practices' ? parts[3] : parts[2];
+      const resTitle = localStorage.getItem(`res_title_${resId}`) || 'Resource';
+      crumbs.push({ text: resTitle });
+    }
+  }
+
+  return (
+    <header className="flex items-center justify-between px-4 py-2 shadow-md bg-white sticky top-0 z-50">
+      {/* Breadcrumb */}
+      <nav className="flex items-center space-x-2 text-sm">
+        {crumbs.map((c, i) => (
+          <React.Fragment key={i}>
+            {c.to ? (
+              <Link to={c.to} className="text-blue-600 hover:underline">
+                {c.text}
+              </Link>
+            ) : (
+              <span className="text-gray-600">{c.text}</span>
+            )}
+            {i < crumbs.length - 1 && <span className="text-gray-400">›</span>}
+          </React.Fragment>
+        ))}
+      </nav>
+
+      {/* Logo */}
+      <button onClick={() => navigate('/dashboard')} className="font-bold text-xl text-blue-600">
+        Sophia
+      </button>
+    </header>
+  );
+}

--- a/myapp/frontend/src/index.js
+++ b/myapp/frontend/src/index.js
@@ -17,6 +17,7 @@ import PrivateRoute from './PrivateRoute';
 import ReviewSubmissions from './pages/ReviewSubmissions';
 import ResourceDetail from './pages/ResourceDetail';
 import PracticeChat from './pages/PracticeChat';
+import AppLayout from './layouts/AppLayout';
 
 function App() {
   return (
@@ -24,59 +25,14 @@ function App() {
       <Routes>
         <Route path="/login" element={<Login />} />
 
-        <Route
-          path="/dashboard"
-          element={
-            <PrivateRoute>
-              <Dashboard />
-            </PrivateRoute>
-          }
-        />
-
-        <Route
-          path="/subjects/:code"
-          element={
-            <PrivateRoute>
-              <SubjectDetail />
-            </PrivateRoute>
-          }
-        />
-
-        <Route
-          path="/subjects/:code/resources/new"
-          element={
-            <PrivateRoute>
-              <NewResource />
-            </PrivateRoute>
-          }
-        />
-
-        <Route
-          path="/resources/:id"
-          element={
-            <PrivateRoute>
-              <ResourceDetail />
-            </PrivateRoute>
-          }
-        />
-
-        <Route
-          path="/subjects/:code/practices/:id"
-          element={
-            <PrivateRoute>
-              <PracticeChat />
-            </PrivateRoute>
-          }
-        />
-
-        <Route
-          path="/resources/:id/review"
-          element={
-            <PrivateRoute>
-              <ReviewSubmissions />
-            </PrivateRoute>
-          }
-        />
+        <Route element={<PrivateRoute><AppLayout /></PrivateRoute>}>
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/subjects/:code" element={<SubjectDetail />} />
+          <Route path="/subjects/:code/resources/new" element={<NewResource />} />
+          <Route path="/resources/:id" element={<ResourceDetail />} />
+          <Route path="/subjects/:code/practices/:id" element={<PracticeChat />} />
+          <Route path="/resources/:id/review" element={<ReviewSubmissions />} />
+        </Route>
 
         <Route path="*" element={<Navigate to="/login" replace />} />
       </Routes>

--- a/myapp/frontend/src/layouts/AppLayout.jsx
+++ b/myapp/frontend/src/layouts/AppLayout.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Navbar from '../components/Navbar';
+import { Outlet } from 'react-router-dom';
+
+export default function AppLayout() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <div className="flex-grow">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/myapp/frontend/src/pages/ResourceDetail.jsx
+++ b/myapp/frontend/src/pages/ResourceDetail.jsx
@@ -59,6 +59,7 @@ export default function ResourceDetail() {
       .then((res) => {
         setResource(res.data);
         setAttachments(res.data.attachments || []);
+        localStorage.setItem(`res_title_${res.data.id}`, res.data.title);
         if (!subjectTitle) {
           api
             .get(`/subjects/${res.data.subject_code}`)

--- a/myapp/frontend/src/pages/SubjectDetail.jsx
+++ b/myapp/frontend/src/pages/SubjectDetail.jsx
@@ -26,6 +26,7 @@ export default function SubjectDetail() {
       // 2) Para cada recurso, si soy alumno, intenta traer solo MI submission
       const resourcesWithSubs = await Promise.all(
         rawResources.map(async (r) => {
+          localStorage.setItem(`res_title_${r.id}`, r.title);
           let submissions = [];
           if (role === 'student') {
             try {
@@ -88,6 +89,7 @@ export default function SubjectDetail() {
       .get(`/subjects/${code}`)
       .then(({ data }) => {
         if (isMounted) setSubject(data);
+        localStorage.setItem(`subj_title_${data.code}`, data.title);
       })
       .catch(console.error);
 


### PR DESCRIPTION
## Summary
- add persistent breadcrumb navbar
- wrap app in new layout with navbar
- persist subject and resource titles for breadcrumbs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870d38d60788321b90dda09ab50a478